### PR TITLE
Check for null in CreativeItemTabFilter.

### DIFF
--- a/src/main/java/net/blay09/mods/refinedrelocation/filter/CreativeTabFilter.java
+++ b/src/main/java/net/blay09/mods/refinedrelocation/filter/CreativeTabFilter.java
@@ -49,6 +49,9 @@ public class CreativeTabFilter implements IChecklistFilter {
 //		CreativeTabs[] itemTabs = itemStack.getItem().getCreativeTabs();
 //		for (CreativeTabs itemTab : itemTabs) {
 		CreativeTabs itemTab = itemStack.getItem().tabToDisplayOn;
+		if (itemTab == null) {
+			return false;
+		}
 		int shiftedTabIndex = itemTab.tabIndex;
 		if(itemTab.tabIndex >= CreativeTabs.SEARCH.tabIndex) {
 			shiftedTabIndex--;


### PR DESCRIPTION
Addresses blay09/RefinedRelocation2#8.

I only did a cursory test (1.10.2 only, alone and with the FTB Infinity Lite 1.10 modpack), but this prevented the crashes I was experiencing associated with the `CreativeItemTabFilter`. The sorting works as expected with the few items I tried.