### PR TITLE
Fixes NullPointerException caused by rotating Fast&Filtered Hopper

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,6 +3,6 @@ major_version=3
 minecraft_version=1.11.2
 minor_version=1
 mappings_version=snapshot_20170213
-forge_version=13.20.0.2230
+forge_version=13.20.1.2388
 mod_name=RefinedRelocation
 mod_id=refinedrelocation

--- a/src/main/java/net/blay09/mods/refinedrelocation/block/BlockFastHopper.java
+++ b/src/main/java/net/blay09/mods/refinedrelocation/block/BlockFastHopper.java
@@ -1,15 +1,16 @@
 package net.blay09.mods.refinedrelocation.block;
 
+import com.google.common.base.Predicate;
 import net.blay09.mods.refinedrelocation.RefinedRelocation;
 import net.blay09.mods.refinedrelocation.api.RefinedRelocationAPI;
 import net.blay09.mods.refinedrelocation.network.GuiHandler;
 import net.blay09.mods.refinedrelocation.network.MessageOpenGui;
 import net.blay09.mods.refinedrelocation.tile.TileFastHopper;
-import net.blay09.mods.refinedrelocation.tile.TileMod;
 import net.minecraft.block.Block;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.properties.PropertyBool;
+import net.minecraft.block.properties.PropertyDirection;
 import net.minecraft.block.state.BlockStateContainer;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.EntityLivingBase;
@@ -28,6 +29,14 @@ import net.minecraft.world.World;
 import javax.annotation.Nullable;
 
 public class BlockFastHopper extends BlockModTile {
+
+	public static final PropertyDirection FACING = PropertyDirection.create("facing", new Predicate<EnumFacing>()
+	{
+		public boolean apply(@Nullable EnumFacing facing)
+		{
+			return facing != EnumFacing.UP;
+		}
+	});
 
 	private static final PropertyBool ENABLED = PropertyBool.create("enabled");
 
@@ -87,7 +96,7 @@ public class BlockFastHopper extends BlockModTile {
 	@SuppressWarnings("deprecation")
 	public AxisAlignedBB getBoundingBox(IBlockState state, IBlockAccess world, BlockPos pos) {
 		if(rayTracePass == 3) {
-			return BOUNDING_BOX_FACING[state.getValue(DIRECTION).ordinal()];
+			return BOUNDING_BOX_FACING[state.getValue(FACING).ordinal()];
 		}
 		return BOUNDING_BOX[rayTracePass];
 	}
@@ -98,7 +107,7 @@ public class BlockFastHopper extends BlockModTile {
 		if (opposite == EnumFacing.UP) {
 			opposite = EnumFacing.DOWN;
 		}
-		return getDefaultState().withProperty(DIRECTION, opposite).withProperty(ENABLED, true);
+		return getDefaultState().withProperty(FACING, opposite).withProperty(ENABLED, true);
 	}
 
 
@@ -111,18 +120,18 @@ public class BlockFastHopper extends BlockModTile {
 
 	@Override
 	protected BlockStateContainer createBlockState() {
-		return new BlockStateContainer(this, DIRECTION, ENABLED);
+		return new BlockStateContainer(this, FACING, ENABLED);
 	}
 
 	@Override
 	@SuppressWarnings("deprecation")
 	public IBlockState getStateFromMeta(int meta) {
-		return getDefaultState().withProperty(DIRECTION, EnumFacing.getFront(meta & 7)).withProperty(ENABLED, (meta & 8) != 8);
+		return getDefaultState().withProperty(FACING, EnumFacing.getFront(meta & 7)).withProperty(ENABLED, (meta & 8) != 8);
 	}
 
 	@Override
 	public int getMetaFromState(IBlockState state) {
-		int meta = (state.getValue(DIRECTION)).getIndex();
+		int meta = (state.getValue(FACING)).getIndex();
 		if (!state.getValue(ENABLED)) {
 			meta |= 8;
 		}
@@ -133,6 +142,20 @@ public class BlockFastHopper extends BlockModTile {
 	@SuppressWarnings("deprecation")
 	public boolean shouldSideBeRendered(IBlockState state, IBlockAccess blockAccess, BlockPos pos, EnumFacing side) {
 		return true;
+	}
+
+	@Nullable
+	@Override
+	public EnumFacing[] getValidRotations(World world, BlockPos pos)
+	{
+		EnumFacing[] result = {
+			EnumFacing.NORTH,
+			EnumFacing.EAST,
+			EnumFacing.SOUTH,
+			EnumFacing.WEST,
+			EnumFacing.DOWN,
+		};
+		return result;
 	}
 
 	@Nullable

--- a/src/main/java/net/blay09/mods/refinedrelocation/tile/TileFastHopper.java
+++ b/src/main/java/net/blay09/mods/refinedrelocation/tile/TileFastHopper.java
@@ -1,6 +1,6 @@
 package net.blay09.mods.refinedrelocation.tile;
 
-import net.blay09.mods.refinedrelocation.block.BlockMod;
+import net.blay09.mods.refinedrelocation.block.BlockFastHopper;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -38,7 +38,7 @@ public class TileFastHopper extends TileMod implements ITickable, INameable {
 		if (world != null && !world.isRemote) {
 			cooldown--;
 			if (cooldown <= 0) {
-				EnumFacing facing = world.getBlockState(getPos()).getValue(BlockMod.DIRECTION);
+				EnumFacing facing = world.getBlockState(getPos()).getValue( BlockFastHopper.FACING );
 				EnumFacing opposite = facing.getOpposite();
 				TileEntity facingTile = world.getTileEntity(pos.offset(facing));
 				IItemHandler targetItemHandler = facingTile != null ? facingTile.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, opposite) : null;


### PR DESCRIPTION
Rotating the Fast or Filtered Hopper with a Wrench, in our case the Crescent Hammer (CoFH), results in a NullPointerException, caused by an undefined "UP" State.

Crash-Report: https://gist.github.com/DerOli82/5bd5c2016d515683c589299e2e2dea75

This fix prevents "UP" State as PropertyDirection.